### PR TITLE
Better Ex Nihilo compat + update GTCEu

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 
     // Hard-Deps
     deobfCompile "curse.maven:mixin-booter-419286:3321174"
-    compile files("gregtech-1.12.2-2.0.0.1373-alpha-dev.jar")
+    compile files("gregtech-1.12.2-2.0.0-alpha.jar")
 
     // Mystical Agriculture mods
     deobfCompile "curse.maven:cucumber-272335:2645867"

--- a/src/main/java/gregification/Gregification.java
+++ b/src/main/java/gregification/Gregification.java
@@ -13,7 +13,7 @@ import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
 
 @Mod(modid = GFValues.MODID, name = GFValues.MOD_NAME, version = GFValues.VERSION,
-        dependencies = "required-after:gregtech@[2.0,);" + "required-after:mixinbooter;" +
+        dependencies = "required-after:gregtech@[2.0.0-alpha,);" + "required-after:mixinbooter;" +
                 "after:gregicality@[1.0,);" +
                 "after:forestry;" +
                 "after:tconstruct;" +

--- a/src/main/java/gregification/common/GFMetaTileEntities.java
+++ b/src/main/java/gregification/common/GFMetaTileEntities.java
@@ -4,7 +4,6 @@ import gregification.config.GFConfig;
 import gregification.exnihilo.metatileentities.MetaTileEntitySieve;
 import gregification.exnihilo.metatileentities.MetaTileEntitySteamSieve;
 import gregtech.api.GTValues;
-import gregtech.api.GregTechAPI;
 import gregtech.common.metatileentities.MetaTileEntities;
 import net.minecraft.util.ResourceLocation;
 

--- a/src/main/java/gregification/common/GFOrePrefix.java
+++ b/src/main/java/gregification/common/GFOrePrefix.java
@@ -49,10 +49,10 @@ public class GFOrePrefix {
         oreNetherChunk = new OrePrefix("oreNetherChunk", -1, null, oreNetherChunkIcon, ENABLE_UNIFICATION, hasOreProperty);
         oreSandyChunk = new OrePrefix("oreSandyChunk", -1, null, oreSandyChunkIcon, ENABLE_UNIFICATION, hasOreProperty);
 
-        oreChunk.setAlternativeOreName(OrePrefix.oreGravel.name());
+        oreChunk.setAlternativeOreName(OrePrefix.ore.name());
         oreEnderChunk.setAlternativeOreName(OrePrefix.oreEndstone.name());
         oreNetherChunk.setAlternativeOreName(OrePrefix.oreNetherrack.name());
-        oreSandyChunk.setAlternativeOreName(OrePrefix.oreSand.name());
+        oreSandyChunk.setAlternativeOreName(OrePrefix.ore.name());
 
         MetaItems.addOrePrefix(oreChunk, oreEnderChunk, oreNetherChunk, oreSandyChunk);
     }

--- a/src/main/java/gregification/common/GFOrePrefix.java
+++ b/src/main/java/gregification/common/GFOrePrefix.java
@@ -8,12 +8,14 @@ import gregtech.api.unification.material.info.MaterialFlags;
 import gregtech.api.unification.material.info.MaterialIconType;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.common.items.MetaItems;
+import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
 import static gregtech.api.unification.ore.OrePrefix.Conditions.hasOreProperty;
 import static gregtech.api.unification.ore.OrePrefix.Flags.ENABLE_UNIFICATION;
 
 // This is just a convenient time to do this
+@Mod.EventBusSubscriber
 public class GFOrePrefix {
 
     // Ex Nihilo
@@ -28,7 +30,7 @@ public class GFOrePrefix {
     public static OrePrefix oreSandyChunk;
 
     @SubscribeEvent
-    public void onMaterialRegisterEvent(GregTechAPI.MaterialEvent event) {
+    public static void onMaterialRegisterEvent(GregTechAPI.MaterialEvent event) {
         materialFlagAdditions();
 
         if (GFConfig.exNihilo.enableExNihilo && GTValues.isModLoaded(GFValues.MODID_EXNI)) {

--- a/src/main/java/gregification/config/ExNihiloCfg.java
+++ b/src/main/java/gregification/config/ExNihiloCfg.java
@@ -124,6 +124,7 @@ public class ExNihiloCfg {
                 "tetrahedrite", "0.1836", "1",
                 "copper", "0.0612", "1",
                 "stibnite", "0.0612", "1",
+                "rutile", "0.0544", "1",
 
                 "redstone", "0.1938", "2",
                 "ruby", "0.0646", "2",
@@ -193,6 +194,7 @@ public class ExNihiloCfg {
                 "tennantite", "0.0663", "1",
                 "tin", "0.24225", "1",
                 "cassiterite", "0.08075", "1",
+                "rutile", "0.0544", "1",
 
                 "bornite", "0.0969", "2",
                 "chalcocite", "0.0969", "2",

--- a/src/main/java/gregification/config/ExNihiloCfg.java
+++ b/src/main/java/gregification/config/ExNihiloCfg.java
@@ -10,6 +10,14 @@ public class ExNihiloCfg {
     @Config.RequiresMcRestart
     public boolean enableExNihilo = true;
 
+    @Config.Comment("Makes Gregification overwrite the sifting table. Default: true")
+    @Config.RequiresMcRestart
+    public boolean GTOverwritedrops = true;
+
+    @Config.Comment("Should Gregification modify the Meshes recipes? Default: true")
+    @Config.RequiresMcRestart
+    public boolean ModifyMeshes = true;
+
     @Config.Comment("Enable High-Tier Sieves (UHV-UXV)? Requires Gregicality to be installed. Default: true")
     @Config.RequiresMcRestart
     public boolean highTierSieve = true;

--- a/src/main/java/gregification/exnihilo/CustomDrops.java
+++ b/src/main/java/gregification/exnihilo/CustomDrops.java
@@ -2,6 +2,7 @@ package gregification.exnihilo;
 
 import exnihilocreatio.ModItems;
 import exnihilocreatio.blocks.BlockSieve;
+import exnihilocreatio.items.seeds.ItemSeedBase;
 import exnihilocreatio.registries.manager.ISieveDefaultRegistryProvider;
 import exnihilocreatio.registries.registries.SieveRegistry;
 import exnihilocreatio.util.ItemInfo;
@@ -30,6 +31,9 @@ public class CustomDrops implements ISieveDefaultRegistryProvider {
         registry.register("dirt", new ItemInfo(Items.PUMPKIN_SEEDS), 0.35f, BlockSieve.MeshType.STRING.getID());
         registry.register("dirt", new ItemInfo(ModItems.resources, 3), 0.05f, BlockSieve.MeshType.STRING.getID());
         registry.register("dirt", new ItemInfo(ModItems.resources, 4), 0.05f, BlockSieve.MeshType.STRING.getID());
+        for (ItemSeedBase seed : ModItems.itemSeeds)  {
+            registry.register("dirt", new ItemInfo(seed), 0.05f, BlockSieve.MeshType.STRING.getID());
+        }
         registry.register("dust", new ItemInfo(Items.DYE, 15), 0.1f, BlockSieve.MeshType.STRING.getID());
         registry.register("dust", new ItemInfo(Items.GLOWSTONE_DUST), 0.025f, BlockSieve.MeshType.IRON.getID());
         registry.register("dust", new ItemInfo(Items.BLAZE_POWDER), 0.037f, BlockSieve.MeshType.IRON.getID());

--- a/src/main/java/gregification/exnihilo/CustomDrops.java
+++ b/src/main/java/gregification/exnihilo/CustomDrops.java
@@ -1,0 +1,38 @@
+package gregification.exnihilo;
+
+import exnihilocreatio.ModItems;
+import exnihilocreatio.blocks.BlockSieve;
+import exnihilocreatio.registries.manager.ISieveDefaultRegistryProvider;
+import exnihilocreatio.registries.registries.SieveRegistry;
+import exnihilocreatio.util.ItemInfo;
+import net.minecraft.init.Items;
+import org.jetbrains.annotations.NotNull;
+
+public class CustomDrops implements ISieveDefaultRegistryProvider {
+    @Override
+    public void registerRecipeDefaults(@NotNull SieveRegistry registry) {
+        registry.clearRegistry();
+
+        registry.register("dirt", new ItemInfo(ModItems.pebbles), 1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles), 1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles), 0.5f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles), 0.5f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles), 0.1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles), 0.1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles, 1), 0.5f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles, 1), 0.1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles, 2), 0.5f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles, 2), 0.1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles, 3), 0.5f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.pebbles, 3), 0.1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(Items.WHEAT_SEEDS), 0.7f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(Items.MELON_SEEDS), 0.35f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(Items.PUMPKIN_SEEDS), 0.35f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.resources, 3), 0.05f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dirt", new ItemInfo(ModItems.resources, 4), 0.05f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dust", new ItemInfo(Items.DYE, 15), 0.1f, BlockSieve.MeshType.STRING.getID());
+        registry.register("dust", new ItemInfo(Items.GLOWSTONE_DUST), 0.025f, BlockSieve.MeshType.IRON.getID());
+        registry.register("dust", new ItemInfo(Items.BLAZE_POWDER), 0.037f, BlockSieve.MeshType.IRON.getID());
+    }
+}
+

--- a/src/main/java/gregification/exnihilo/MeshRecipes.java
+++ b/src/main/java/gregification/exnihilo/MeshRecipes.java
@@ -1,31 +1,73 @@
 package gregification.exnihilo;
 
+import exnihilocreatio.ModBlocks;
 import exnihilocreatio.ModItems;
+import gregification.config.GFConfig;
 import gregtech.api.recipes.ModHandler;
 import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.ore.OrePrefix;
 import gregtech.api.unification.stack.UnificationEntry;
+import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
+
+import static gregtech.api.recipes.RecipeMaps.FORGE_HAMMER_RECIPES;
+
 
 public class MeshRecipes {
     public static void init() {
-        ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_2");
-        ModHandler.addShapedRecipe("tin_alloy_mesh", new ItemStack(ModItems.mesh, 1, 2), "TST", "STS", "TST",
-                'T', new UnificationEntry(OrePrefix.stick, Materials.TinAlloy),
-                'S', new ItemStack(Items.STRING)
-                );
-        ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_3");
-        ModHandler.addShapedRecipe("steel_mesh", new ItemStack(ModItems.mesh, 1, 3), "TST", "STS", "TST",
-                'T', new UnificationEntry(OrePrefix.stick, Materials.Steel),
-                'S', new ItemStack(Items.STRING)
-        );
-        ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_4");
-        ModHandler.addShapedRecipe("aluminium_mesh", new ItemStack(ModItems.mesh, 1, 4), "TST", "STS", "TST",
-                'T', new UnificationEntry(OrePrefix.stick, Materials.Aluminium),
-                'S', new ItemStack(Items.STRING)
-        );
-    }
+        if (GFConfig.exNihilo.ModifyMeshes) {
+            ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_2");
+            ModHandler.addShapedRecipe("tin_alloy_mesh", new ItemStack(ModItems.mesh, 1, 2), "TST", "STS", "TST",
+                    'T', new UnificationEntry(OrePrefix.stick, Materials.TinAlloy),
+                    'S', new ItemStack(Items.STRING)
+            );
+            ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_3");
+            ModHandler.addShapedRecipe("steel_mesh", new ItemStack(ModItems.mesh, 1, 3), "TST", "STS", "TST",
+                    'T', new UnificationEntry(OrePrefix.stick, Materials.Steel),
+                    'S', new ItemStack(Items.STRING)
+            );
+            ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_4");
+            ModHandler.addShapedRecipe("aluminium_mesh", new ItemStack(ModItems.mesh, 1, 4), "TST", "STS", "TST",
+                    'T', new UnificationEntry(OrePrefix.stick, Materials.Aluminium),
+                    'S', new ItemStack(Items.STRING)
+            );
+        }
 
+        FORGE_HAMMER_RECIPES.recipeBuilder()
+                .duration(10).EUt(16)
+                .input(Blocks.SAND)
+                .output(ModBlocks.dust)
+                .buildAndRegister();
+
+        FORGE_HAMMER_RECIPES.recipeBuilder()
+                .duration(10).EUt(16)
+                .inputs(new ItemStack(Blocks.STONE, 1, 1))
+                .output(ModBlocks.crushedGranite)
+                .buildAndRegister();
+
+        FORGE_HAMMER_RECIPES.recipeBuilder()
+                .duration(10).EUt(16)
+                .inputs(new ItemStack(Blocks.STONE, 1, 3))
+                .output(ModBlocks.crushedDiorite)
+                .buildAndRegister();
+
+        FORGE_HAMMER_RECIPES.recipeBuilder()
+                .duration(10).EUt(16)
+                .inputs(new ItemStack(Blocks.STONE, 1, 5))
+                .output(ModBlocks.crushedAndesite)
+                .buildAndRegister();
+
+        FORGE_HAMMER_RECIPES.recipeBuilder()
+                .duration(10).EUt(16)
+                .input(Blocks.NETHERRACK)
+                .output(ModBlocks.netherrackCrushed)
+                .buildAndRegister();
+
+        FORGE_HAMMER_RECIPES.recipeBuilder()
+                .duration(10).EUt(16)
+                .input(Blocks.END_STONE)
+                .output(ModBlocks.endstoneCrushed)
+                .buildAndRegister();
+    }
 }

--- a/src/main/java/gregification/exnihilo/MeshRecipes.java
+++ b/src/main/java/gregification/exnihilo/MeshRecipes.java
@@ -1,0 +1,31 @@
+package gregification.exnihilo;
+
+import exnihilocreatio.ModItems;
+import gregtech.api.recipes.ModHandler;
+import gregtech.api.unification.material.Materials;
+import gregtech.api.unification.ore.OrePrefix;
+import gregtech.api.unification.stack.UnificationEntry;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.ResourceLocation;
+
+public class MeshRecipes {
+    public static void init() {
+        ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_2");
+        ModHandler.addShapedRecipe("tin_alloy_mesh", new ItemStack(ModItems.mesh, 1, 2), "TST", "STS", "TST",
+                'T', new UnificationEntry(OrePrefix.stick, Materials.TinAlloy),
+                'S', new ItemStack(Items.STRING)
+                );
+        ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_3");
+        ModHandler.addShapedRecipe("steel_mesh", new ItemStack(ModItems.mesh, 1, 3), "TST", "STS", "TST",
+                'T', new UnificationEntry(OrePrefix.stick, Materials.Steel),
+                'S', new ItemStack(Items.STRING)
+        );
+        ModHandler.removeRecipeByName("exnihilocreatio:item_mesh_4");
+        ModHandler.addShapedRecipe("aluminium_mesh", new ItemStack(ModItems.mesh, 1, 4), "TST", "STS", "TST",
+                'T', new UnificationEntry(OrePrefix.stick, Materials.Aluminium),
+                'S', new ItemStack(Items.STRING)
+        );
+    }
+
+}

--- a/src/main/java/gregification/exnihilo/SieveDrops.java
+++ b/src/main/java/gregification/exnihilo/SieveDrops.java
@@ -27,7 +27,6 @@ import gregification.common.GFOrePrefix;
 import gregtech.api.GregTechAPI;
 import gregtech.api.unification.OreDictUnifier;
 import gregtech.api.unification.material.Material;
-import gregtech.api.unification.material.Materials;
 import gregtech.api.unification.material.properties.PropertyKey;
 import gregtech.api.unification.ore.OrePrefix;
 import net.minecraft.item.ItemStack;

--- a/src/main/java/gregification/exnihilo/metatileentities/MetaTileEntitySieve.java
+++ b/src/main/java/gregification/exnihilo/metatileentities/MetaTileEntitySieve.java
@@ -27,7 +27,7 @@ import gregtech.api.gui.widgets.ToggleButtonWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
-import gregtech.api.render.Textures;
+import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 

--- a/src/main/java/gregification/exnihilo/metatileentities/MetaTileEntitySteamSieve.java
+++ b/src/main/java/gregification/exnihilo/metatileentities/MetaTileEntitySteamSieve.java
@@ -18,19 +18,18 @@
 package gregification.exnihilo.metatileentities;
 
 import gregification.common.GFRecipeMaps;
+import gregtech.api.gui.GuiTextures;
 import gregtech.api.gui.ModularUI;
-import gregtech.api.gui.widgets.ImageWidget;
-import gregtech.api.gui.widgets.LabelWidget;
 import gregtech.api.gui.widgets.ProgressWidget;
-import gregtech.api.gui.widgets.SlotWidget;
 import gregtech.api.metatileentity.MetaTileEntity;
 import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SteamMetaTileEntity;
-import gregtech.api.render.Textures;
+import gregtech.client.renderer.texture.Textures;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemStackHandler;
+
 
 public class MetaTileEntitySteamSieve extends SteamMetaTileEntity {
 
@@ -39,10 +38,10 @@ public class MetaTileEntitySteamSieve extends SteamMetaTileEntity {
     }
 
     @Override
-    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder holder) {
+    public MetaTileEntity createMetaTileEntity(MetaTileEntityHolder metaTileEntityHolder) {
         return new MetaTileEntitySteamSieve(metaTileEntityId, isHighPressure);
     }
-
+    
     @Override
     public IItemHandlerModifiable createImportItemHandler() {
         return new ItemStackHandler(2);
@@ -54,24 +53,16 @@ public class MetaTileEntitySteamSieve extends SteamMetaTileEntity {
     }
 
     @Override
-    public ModularUI createUI(EntityPlayer player) {
-        ModularUI.Builder builder = ModularUI.extendedBuilder()
-                .widget(new LabelWidget(6, 6, getMetaFullName()))
-                .widget(new ImageWidget(79, 42, 18, 18, getFullGuiTexture("not_enough_steam_%s"))
-                        .setPredicate(() -> workableHandler.isHasNotEnoughEnergy()))
-                .bindPlayerInventory(player.inventory, BRONZE_SLOT_BACKGROUND_TEXTURE, 8, 134)
-                .widget(new SlotWidget(this.importItems, 0, 35, 25)
-                        .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE))
-                .widget(new SlotWidget(this.importItems, 1, 53, 25)
-                        .setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE))
-                .widget(new ProgressWidget(workableHandler::getProgressPercent, 78, 24, 20, 18)
-                        .setProgressBar(getFullGuiTexture("progress_bar_%s_macerator"),
-                                getFullGuiTexture("progress_bar_%s_macerator_filled"),
-                                ProgressWidget.MoveType.HORIZONTAL));
+    protected ModularUI createUI(EntityPlayer player) {
+        ModularUI.Builder builder = ModularUI.builder(GuiTextures.BACKGROUND_STEAM.get(isHighPressure), 180, 220)
+                .slot(this.importItems, 0, 35, 25, GuiTextures.SLOT_STEAM.get(isHighPressure))
+                .slot(this.importItems, 1, 53, 25, GuiTextures.SLOT_STEAM.get(isHighPressure))
+                .bindPlayerInventory(player.inventory, GuiTextures.SLOT_STEAM.get(isHighPressure), 8, 134)
+                .progressBar(workableHandler::getProgressPercent, 78, 24, 20, 18, GuiTextures.PROGRESS_BAR_MACERATE, ProgressWidget.MoveType.HORIZONTAL);
 
         for (int y = 0; y < 6; y++) {
             for (int x = 0; x < 4; x++) {
-                builder.widget(new SlotWidget(this.exportItems, y * 4 + x, 98 + x * 18, 7 + y * 18, true, false).setBackgroundTexture(BRONZE_SLOT_BACKGROUND_TEXTURE));
+                builder.slot(this.exportItems, y * 4 + x, 98 + x * 18, 7 + y * 18, true, false, GuiTextures.SLOT_STEAM.get(isHighPressure));
             }
         }
 

--- a/src/main/java/gregification/proxy/ExNihiloCommonProxy.java
+++ b/src/main/java/gregification/proxy/ExNihiloCommonProxy.java
@@ -43,9 +43,7 @@ public class ExNihiloCommonProxy {
     public void init() {
         if (GFConfig.exNihilo.enableExNihilo) {
             ExNihiloRecipes.registerExNihiloRecipes();
-            if (GFConfig.exNihilo.ModifyMeshes) {
-                MeshRecipes.init();
-            }
+            MeshRecipes.init();
         }
     }
 }

--- a/src/main/java/gregification/proxy/ExNihiloCommonProxy.java
+++ b/src/main/java/gregification/proxy/ExNihiloCommonProxy.java
@@ -21,6 +21,9 @@ public class ExNihiloCommonProxy {
             GFLog.exNihiloLogger.info("Registering Ex Nihilo Compat Items, Blocks, and Machines");
             ExNihiloPebble.register();
             SieveDrops.readSieveDropsFromConfig();
+            if (GFConfig.exNihilo.GTOverwritedrops) {
+                ExNihiloRegistryManager.registerSieveDefaultRecipeHandler(new CustomDrops());
+            }
             ExNihiloRegistryManager.registerSieveDefaultRecipeHandler(new SieveDrops());
             GFMetaTileEntities.registerExNihilo();
         }
@@ -40,6 +43,9 @@ public class ExNihiloCommonProxy {
     public void init() {
         if (GFConfig.exNihilo.enableExNihilo) {
             ExNihiloRecipes.registerExNihiloRecipes();
+            if (GFConfig.exNihilo.ModifyMeshes) {
+                MeshRecipes.init();
+            }
         }
     }
 }


### PR DESCRIPTION
This PR fixes the Ex Nihilo compat crash and enhances it by adding 2 new config options:

- Overwrite sifting table
This option makes that the sifting table gets cleared and complete replaced through Gregification's one.

- Modify Mesh recipes
This option makes that the Mesh recipes gets modified to fit the progression.