### PR TITLE
Add World Accelerator  OC Driver, cleanup

### DIFF
--- a/src/main/java/gregification/opencomputers/drivers/DriverAbstractRecipeLogic.java
+++ b/src/main/java/gregification/opencomputers/drivers/DriverAbstractRecipeLogic.java
@@ -20,7 +20,7 @@ package gregification.opencomputers.drivers;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
 import gregtech.api.capability.impl.AbstractRecipeLogic;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.recipes.CountableIngredient;
 import gregtech.api.recipes.Recipe;
 import li.cil.oc.api.machine.Arguments;
@@ -34,7 +34,6 @@ import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.FluidStack;
-import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,7 +51,7 @@ public class DriverAbstractRecipeLogic extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
+        if (tileEntity instanceof IGregTechTileEntity) {
             return tileEntity.hasCapability(GregtechTileCapabilities.CAPABILITY_WORKABLE, side);
         }
         return false;
@@ -61,10 +60,10 @@ public class DriverAbstractRecipeLogic extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
+        if (tileEntity instanceof IGregTechTileEntity) {
             IWorkable capability = tileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_WORKABLE, side);
             if (capability instanceof AbstractRecipeLogic)
-                return new EnvironmentAbstractRecipeLogic((MetaTileEntityHolder) tileEntity,
+                return new EnvironmentAbstractRecipeLogic((IGregTechTileEntity) tileEntity,
                         (AbstractRecipeLogic) capability);
         }
         return null;
@@ -72,13 +71,12 @@ public class DriverAbstractRecipeLogic extends DriverSidedTileEntity {
 
     public final static class EnvironmentAbstractRecipeLogic extends EnvironmentMetaTileEntity<AbstractRecipeLogic> {
 
-        public EnvironmentAbstractRecipeLogic(MetaTileEntityHolder holder, AbstractRecipeLogic capability) {
-            super(holder, capability, "gtce_abstractRecipeLogic");
+        public EnvironmentAbstractRecipeLogic(IGregTechTileEntity holder, AbstractRecipeLogic capability) {
+            super(holder, capability, "gt_recipeLogic");
         }
 
         @Callback(doc = "function():table -- Returns previous recipe.")
         public Object[] getCurrentRecipe(final Context context, final Arguments args) {
-            //noinspection deprecation
             Recipe previousRecipe = tileEntity.getPreviousRecipe();
             if (previousRecipe != null && tileEntity.isActive()) {
                 HashMap<String, Object> recipe = new HashMap<>();

--- a/src/main/java/gregification/opencomputers/drivers/DriverEnergyContainer.java
+++ b/src/main/java/gregification/opencomputers/drivers/DriverEnergyContainer.java
@@ -6,7 +6,7 @@ package gregification.opencomputers.drivers;
 
 import gregtech.api.capability.GregtechCapabilities;
 import gregtech.api.capability.IEnergyContainer;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -28,7 +28,7 @@ public class DriverEnergyContainer extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
+        if (tileEntity instanceof IGregTechTileEntity) {
             return tileEntity.hasCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, side);
         }
         return false;
@@ -37,8 +37,8 @@ public class DriverEnergyContainer extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return new EnvironmentIEnergyContainer((MetaTileEntityHolder) tileEntity,
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentIEnergyContainer((IGregTechTileEntity) tileEntity,
                     tileEntity.getCapability(GregtechCapabilities.CAPABILITY_ENERGY_CONTAINER, side)
             );
         }
@@ -47,8 +47,8 @@ public class DriverEnergyContainer extends DriverSidedTileEntity {
 
     public static final class EnvironmentIEnergyContainer extends EnvironmentMetaTileEntity<IEnergyContainer> {
 
-        public EnvironmentIEnergyContainer(MetaTileEntityHolder holder, IEnergyContainer capability) {
-            super(holder, capability, "gtce_energyContainer");
+        public EnvironmentIEnergyContainer(IGregTechTileEntity holder, IEnergyContainer capability) {
+            super(holder, capability, "gt_energyContainer");
         }
 
         @Callback(doc = "function():number --  Returns the amount of electricity contained in this Block, in EU units!")

--- a/src/main/java/gregification/opencomputers/drivers/DriverICoverable.java
+++ b/src/main/java/gregification/opencomputers/drivers/DriverICoverable.java
@@ -21,7 +21,7 @@ import gregification.opencomputers.values.*;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.cover.CoverBehavior;
 import gregtech.api.cover.ICoverable;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.common.covers.*;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
@@ -44,7 +44,7 @@ public class DriverICoverable extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
+        if (tileEntity instanceof IGregTechTileEntity) {
             return tileEntity.hasCapability(GregtechTileCapabilities.CAPABILITY_COVERABLE, side);
         }
         return false;
@@ -53,8 +53,8 @@ public class DriverICoverable extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return new EnvironmentICoverable((MetaTileEntityHolder) tileEntity,
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentICoverable((IGregTechTileEntity) tileEntity,
                     tileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_COVERABLE, null));
         }
         return null;
@@ -62,8 +62,8 @@ public class DriverICoverable extends DriverSidedTileEntity {
 
     public final static class EnvironmentICoverable extends EnvironmentMetaTileEntity<ICoverable> {
 
-        public EnvironmentICoverable(MetaTileEntityHolder holder, ICoverable capability) {
-            super(holder, capability, "gtce_workable");
+        public EnvironmentICoverable(IGregTechTileEntity holder, ICoverable capability) {
+            super(holder, capability, "gt_coverable");
         }
 
         @Callback(doc = "function(side:number):table --  Returns cover of side!")

--- a/src/main/java/gregification/opencomputers/drivers/DriverRecipeMapMultiblockController.java
+++ b/src/main/java/gregification/opencomputers/drivers/DriverRecipeMapMultiblockController.java
@@ -20,7 +20,7 @@ package gregification.opencomputers.drivers;
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IMultipleTankHandler;
 import gregtech.api.capability.impl.MultiblockRecipeLogic;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.api.metatileentity.multiblock.RecipeMapMultiblockController;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
@@ -52,7 +52,7 @@ public class DriverRecipeMapMultiblockController extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
+        if (tileEntity instanceof IGregTechTileEntity) {
             return tileEntity.hasCapability(GregtechTileCapabilities.CAPABILITY_WORKABLE, side);
         }
         return false;
@@ -61,18 +61,18 @@ public class DriverRecipeMapMultiblockController extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            if (((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof RecipeMapMultiblockController)
-                return new EnvironmentMultiblockRecipeLogic((MetaTileEntityHolder) tileEntity,
-                        (RecipeMapMultiblockController) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity());
+        if (tileEntity instanceof IGregTechTileEntity) {
+            if (((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof RecipeMapMultiblockController)
+                return new EnvironmentMultiblockRecipeLogic((IGregTechTileEntity) tileEntity,
+                        (RecipeMapMultiblockController) ((IGregTechTileEntity) tileEntity).getMetaTileEntity());
         }
         return null;
     }
 
     public final static class EnvironmentMultiblockRecipeLogic extends EnvironmentMetaTileEntity<RecipeMapMultiblockController> {
 
-        public EnvironmentMultiblockRecipeLogic(MetaTileEntityHolder holder, RecipeMapMultiblockController capability) {
-            super(holder, capability, "gtce_multiblockRecipeLogic");
+        public EnvironmentMultiblockRecipeLogic(IGregTechTileEntity holder, RecipeMapMultiblockController capability) {
+            super(holder, capability, "gt_multiblockRecipeLogic");
         }
 
         @Callback(doc = "function():number --  Returns the amount of electricity contained in this Block, in EU units!")

--- a/src/main/java/gregification/opencomputers/drivers/DriverSimpleMachine.java
+++ b/src/main/java/gregification/opencomputers/drivers/DriverSimpleMachine.java
@@ -17,8 +17,8 @@
  */
 package gregification.opencomputers.drivers;
 
-import gregtech.api.metatileentity.MetaTileEntityHolder;
 import gregtech.api.metatileentity.SimpleMachineMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -40,8 +40,8 @@ public class DriverSimpleMachine extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof SimpleMachineMetaTileEntity;
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof SimpleMachineMetaTileEntity;
         }
         return false;
     }
@@ -49,9 +49,9 @@ public class DriverSimpleMachine extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return new EnvironmentSimpleMachine((MetaTileEntityHolder) tileEntity,
-                    (SimpleMachineMetaTileEntity) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentSimpleMachine((IGregTechTileEntity) tileEntity,
+                    (SimpleMachineMetaTileEntity) ((IGregTechTileEntity) tileEntity).getMetaTileEntity()
             );
         }
         return null;
@@ -59,8 +59,8 @@ public class DriverSimpleMachine extends DriverSidedTileEntity {
 
     public final static class EnvironmentSimpleMachine extends EnvironmentMetaTileEntity<SimpleMachineMetaTileEntity> {
 
-        public EnvironmentSimpleMachine(MetaTileEntityHolder holder, SimpleMachineMetaTileEntity tileEntity) {
-            super(holder, tileEntity, "gtce_simpleMachineMetaTileEntity");
+        public EnvironmentSimpleMachine(IGregTechTileEntity holder, SimpleMachineMetaTileEntity tileEntity) {
+            super(holder, tileEntity, "gt_machine");
         }
 
         @Callback(doc = "function():number --  Returns the tier of machine.")

--- a/src/main/java/gregification/opencomputers/drivers/DriverWorkable.java
+++ b/src/main/java/gregification/opencomputers/drivers/DriverWorkable.java
@@ -6,7 +6,7 @@ package gregification.opencomputers.drivers;
 
 import gregtech.api.capability.GregtechTileCapabilities;
 import gregtech.api.capability.IWorkable;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
 import li.cil.oc.api.machine.Context;
@@ -28,7 +28,7 @@ public class DriverWorkable extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
+        if (tileEntity instanceof IGregTechTileEntity) {
             return tileEntity.hasCapability(GregtechTileCapabilities.CAPABILITY_WORKABLE, side);
         }
         return false;
@@ -37,8 +37,8 @@ public class DriverWorkable extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return new EnvironmentIWorkable((MetaTileEntityHolder) tileEntity,
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentIWorkable((IGregTechTileEntity) tileEntity,
                     tileEntity.getCapability(GregtechTileCapabilities.CAPABILITY_WORKABLE, side)
             );
         }
@@ -47,8 +47,8 @@ public class DriverWorkable extends DriverSidedTileEntity {
 
     public final static class EnvironmentIWorkable extends EnvironmentMetaTileEntity<IWorkable> {
 
-        public EnvironmentIWorkable(MetaTileEntityHolder holder, IWorkable capability) {
-            super(holder, capability, "gtce_workable");
+        public EnvironmentIWorkable(IGregTechTileEntity holder, IWorkable capability) {
+            super(holder, capability, "gt_workable");
         }
 
         @Callback(doc = "function():number --  Returns the MaxProgress!")

--- a/src/main/java/gregification/opencomputers/drivers/EnvironmentMetaTileEntity.java
+++ b/src/main/java/gregification/opencomputers/drivers/EnvironmentMetaTileEntity.java
@@ -17,7 +17,7 @@
  */
 package gregification.opencomputers.drivers;
 
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import li.cil.oc.api.driver.NamedBlock;
 import li.cil.oc.integration.ManagedTileEntityEnvironment;
 
@@ -26,7 +26,7 @@ public abstract class EnvironmentMetaTileEntity<T> extends ManagedTileEntityEnvi
 
     private final String preferredName;
 
-    public EnvironmentMetaTileEntity(MetaTileEntityHolder holder, T capability, String name) {
+    public EnvironmentMetaTileEntity(IGregTechTileEntity holder, T capability, String name) {
         super(capability, name);
         preferredName = holder.getMetaTileEntity().metaTileEntityId.getPath();
     }

--- a/src/main/java/gregification/opencomputers/drivers/specific/DriverFusionReactor.java
+++ b/src/main/java/gregification/opencomputers/drivers/specific/DriverFusionReactor.java
@@ -18,7 +18,7 @@
 package gregification.opencomputers.drivers.specific;
 
 import gregification.opencomputers.drivers.EnvironmentMetaTileEntity;
-import gregtech.api.metatileentity.MetaTileEntityHolder;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
 import gregtech.common.metatileentities.multi.electric.MetaTileEntityFusionReactor;
 import li.cil.oc.api.machine.Arguments;
 import li.cil.oc.api.machine.Callback;
@@ -41,8 +41,8 @@ public class DriverFusionReactor extends DriverSidedTileEntity {
     @Override
     public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return ((MetaTileEntityHolder) tileEntity).getMetaTileEntity() instanceof MetaTileEntityFusionReactor;
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityFusionReactor;
         }
         return false;
     }
@@ -50,9 +50,9 @@ public class DriverFusionReactor extends DriverSidedTileEntity {
     @Override
     public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
         TileEntity tileEntity = world.getTileEntity(pos);
-        if (tileEntity instanceof MetaTileEntityHolder) {
-            return new EnvironmentFusionReactor((MetaTileEntityHolder) tileEntity,
-                    (MetaTileEntityFusionReactor) ((MetaTileEntityHolder) tileEntity).getMetaTileEntity()
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentFusionReactor((IGregTechTileEntity) tileEntity,
+                    (MetaTileEntityFusionReactor) ((IGregTechTileEntity) tileEntity).getMetaTileEntity()
             );
         }
         return null;
@@ -61,8 +61,8 @@ public class DriverFusionReactor extends DriverSidedTileEntity {
     public final static class EnvironmentFusionReactor extends
             EnvironmentMetaTileEntity<MetaTileEntityFusionReactor> {
 
-        public EnvironmentFusionReactor(MetaTileEntityHolder holder, MetaTileEntityFusionReactor tileEntity) {
-            super(holder, tileEntity, "gtce_tileEntityFusionReactor");
+        public EnvironmentFusionReactor(IGregTechTileEntity holder, MetaTileEntityFusionReactor tileEntity) {
+            super(holder, tileEntity, "gt_fusionReactor");
         }
 
         @Callback(doc = "function():number --  Returns the heat of machine.")

--- a/src/main/java/gregification/opencomputers/drivers/specific/DriverWorldAccelerator.java
+++ b/src/main/java/gregification/opencomputers/drivers/specific/DriverWorldAccelerator.java
@@ -1,0 +1,93 @@
+/*
+    Copyright 2020, decal06, dan
+    Gregicality
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package gregification.opencomputers.drivers.specific;
+
+import gregification.opencomputers.drivers.EnvironmentMetaTileEntity;
+import gregtech.api.metatileentity.interfaces.IGregTechTileEntity;
+import gregtech.common.metatileentities.electric.MetaTileEntityWorldAccelerator;
+import li.cil.oc.api.machine.Arguments;
+import li.cil.oc.api.machine.Callback;
+import li.cil.oc.api.machine.Context;
+import li.cil.oc.api.network.ManagedEnvironment;
+import li.cil.oc.api.prefab.DriverSidedTileEntity;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.EnumFacing;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@SuppressWarnings("unused")
+public class DriverWorldAccelerator extends DriverSidedTileEntity {
+
+    @Override
+    public Class<?> getTileEntityClass() {
+        return MetaTileEntityWorldAccelerator.class;
+    }
+
+    @Override
+    public boolean worksWith(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return ((IGregTechTileEntity) tileEntity).getMetaTileEntity() instanceof MetaTileEntityWorldAccelerator;
+        }
+        return false;
+    }
+
+    @Override
+    public ManagedEnvironment createEnvironment(World world, BlockPos pos, EnumFacing side) {
+        TileEntity tileEntity = world.getTileEntity(pos);
+        if (tileEntity instanceof IGregTechTileEntity) {
+            return new EnvironmentTileEntityWorldAccelerator((IGregTechTileEntity) tileEntity,
+                    (MetaTileEntityWorldAccelerator) ((IGregTechTileEntity) tileEntity).getMetaTileEntity()
+            );
+        }
+        return null;
+    }
+
+    public final static class EnvironmentTileEntityWorldAccelerator extends
+            EnvironmentMetaTileEntity<MetaTileEntityWorldAccelerator> {
+
+        public EnvironmentTileEntityWorldAccelerator(IGregTechTileEntity holder, MetaTileEntityWorldAccelerator tileEntity) {
+            super(holder, tileEntity, "gt_worldAccelerator");
+        }
+
+        @Callback(doc = "function():boolean --  Returns the mode of machine.")
+        public Object[] isTileMode(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.isTEMode()};
+        }
+
+        @Callback(doc = "function(isTile:boolean) --  Sets the mode of machine.")
+        public Object[] setTileMode(final Context context, final Arguments args) {
+            tileEntity.setTEMode(args.checkBoolean(0));
+            return new Object[] {};
+        }
+
+        @Callback(doc = "function():boolean --  Returns is working enabled.")
+        public Object[] isWorkingEnabled(final Context context, final Arguments args) {
+            return new Object[] {tileEntity.isWorkingEnabled()};
+        }
+
+        @Callback(doc = "function(workingEnabled:boolean):boolean -- "
+                + "Sets working enabled, return last working enabled.")
+        public Object[] setWorkingEnabled(final Context context, final Arguments args) {
+            boolean lsatState = tileEntity.isWorkingEnabled();
+            tileEntity.setWorkingEnabled(args.checkBoolean(0));
+            return new Object[] {lsatState};
+        }
+
+    }
+}

--- a/src/main/java/gregification/proxy/OCCommonProxy.java
+++ b/src/main/java/gregification/proxy/OCCommonProxy.java
@@ -26,12 +26,12 @@ public class OCCommonProxy {
             Driver.add(new DriverICoverable());
             Driver.add(new DriverSimpleMachine());
             Driver.add(new DriverFusionReactor());
+            Driver.add(new DriverWorldAccelerator());
 
             // TODO Waiting on Gregicality to be at least functional with CEu
             //if (GFConfig.openComputers.enableGregicalityOC && GTValues.isModLoaded(GFValues.MODID_GCY)) {
                 //Driver.add(new DriverNuclearReactor());
                 //Driver.add(new DriverVoidMiner());
-                //Driver.add(new DriverWorldAccelerator()); // todo this may move to CEu
                 //Driver.add(new DriverQubitMultiblockController());
                 //Driver.add(new DriverBatteryTower()); // todo this will move to CEu
             //}


### PR DESCRIPTION
Adds an OC Driver to the World Accelerator (ported from GCYL) and cleans up the other drivers to use the new MTE interfaces rather than MetaTileEntityHolder