### PR TITLE
Catch NoClassDefFoundError in AnnotationProcessor

### DIFF
--- a/src/main/java/gregification/base/AnnotationProcessor.java
+++ b/src/main/java/gregification/base/AnnotationProcessor.java
@@ -20,7 +20,7 @@ public class AnnotationProcessor {
             Class<?> clazz;
             try {
                 clazz = Class.forName(className);
-            } catch (ClassNotFoundException e) {
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
                 Gregification.logger.error("Failed to load {} module, malformed annotation data", className);
                 continue;
             }


### PR DESCRIPTION
Fixes a crash from the absence of exnihilo by catching a `NoClassDefFoundError` along side a `ClassNotFoundException`.